### PR TITLE
fix: recipe details display and ingredients formatting

### DIFF
--- a/app/src/main/java/com/example/cookmate/ui/adapter/IngredientsAdapter.kt
+++ b/app/src/main/java/com/example/cookmate/ui/adapter/IngredientsAdapter.kt
@@ -8,29 +8,40 @@ import androidx.recyclerview.widget.RecyclerView
 import com.example.cookmate.R
 import com.example.cookmate.data.model.Ingredient
 
+/**
+ * Adapter for displaying recipe ingredients in a RecyclerView
+ * @property ingredients List of ingredients to display
+ */
 class IngredientsAdapter(private val ingredients: List<Ingredient>) :
     RecyclerView.Adapter<IngredientsAdapter.IngredientViewHolder>() {
 
+    /**
+     * ViewHolder for ingredient items
+     * Displays ingredient name, amount, and substitutes if available
+     */
     inner class IngredientViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         private val ingredientName: TextView = itemView.findViewById(R.id.ingredientName)
         private val ingredientAmount: TextView = itemView.findViewById(R.id.ingredientAmount)
-        private val ingredientSubstitute: TextView = itemView.findViewById(R.id.ingredientSubstitute)
 
+        /**
+         * Binds ingredient data to the view
+         * @param ingredient The ingredient to display
+         */
         fun bind(ingredient: Ingredient) {
-            "${ingredient.name} - ".also { ingredientName.text = it }
-            "${ingredient.amount} - ".also { ingredientAmount.text = it }
-            if (ingredient.substitutes != null) {
-                " (${ingredient.substitutes})".also { ingredientSubstitute.text = it }
-                ingredientSubstitute.visibility = View.VISIBLE
-            } else {
-                ingredientSubstitute.visibility = View.GONE
-            }
+            // Format: "Name - Amount Unit [substitutes]"
+            val substitutesText = if (!ingredient.substitutes.isNullOrEmpty()) {
+                " [${ingredient.substitutes.joinToString(", ")}]"
+            } else ""
+            
+            val amountText = "${ingredient.amount} ${ingredient.unit}"
+            ingredientAmount.text = amountText
+            ingredientName.text = "${ingredient.name}$substitutesText"
         }
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): IngredientViewHolder {
         val view = LayoutInflater.from(parent.context)
-            .inflate(R.layout.ingredient_item, parent, false)
+            .inflate(R.layout.item_ingredient_detail, parent, false)
         return IngredientViewHolder(view)
     }
 

--- a/app/src/main/java/com/example/cookmate/ui/view/activity/RecipeDetailsActivity.kt
+++ b/app/src/main/java/com/example/cookmate/ui/view/activity/RecipeDetailsActivity.kt
@@ -52,7 +52,11 @@ class RecipeDetailsActivity : AppCompatActivity() {
 
         // Get recipe details from intent
         intent.extras?.let { bundle ->
+            // Recipe basic info
             binding.recipeName.text = bundle.getString("recipe_name", "")
+            binding.recipeDescription.text = bundle.getString("recipe_description", "")
+
+            // Image handling
             val imageUrl = bundle.getString("recipe_image_url")
             if (imageUrl != null) {
                 Glide.with(this)
@@ -65,13 +69,28 @@ class RecipeDetailsActivity : AppCompatActivity() {
                 )
             }
 
-            // Set cooking info
-            binding.prepTimeValue.text = bundle.getString("recipe_time", "N/A")
+            // Cooking info
+            binding.prepTimeValue.text = bundle.getString("recipe_prep_time", "N/A")
+            binding.cookingTimeValue.text = bundle.getString("recipe_time", "N/A")
             binding.servingSizeValue.text = bundle.getString("recipe_servings", "N/A")
 
+            // Nutrition info
+            val calories = bundle.getSerializable("calories") as? Pair<Float, String>
+            val fat = bundle.getSerializable("fat") as? Pair<Float, String>
+            val carbs = bundle.getSerializable("carbs") as? Pair<Float, String>
+            val protein = bundle.getSerializable("protein") as? Pair<Float, String>
+
+            binding.caloriesText.text = "Calories: ${calories?.first ?: 0} ${calories?.second ?: "kcal"}"
+            binding.fatText.text = "Fat: ${fat?.first ?: 0} ${fat?.second ?: "g"}"
+            binding.carbsText.text = "Carbohydrates: ${carbs?.first ?: 0} ${carbs?.second ?: "g"}"
+            binding.proteinText.text = "Protein: ${protein?.first ?: 0} ${protein?.second ?: "g"}"
+
+            // Ingredients
             val ingredients = getSerializable(this, "ingredients", ArrayList::class.java) as ArrayList<Ingredient>
-            Log.d("ingredients size", "${ingredients.size}")
             ingredientsAdapter = IngredientsAdapter(ingredients)
+            
+            // Preparation steps
+            binding.preparationSteps.text = bundle.getString("recipe_preparation_steps", "")
         }
         ingredientsRecyclerView.apply {
             layoutManager = LinearLayoutManager(this@RecipeDetailsActivity)

--- a/app/src/main/java/com/example/cookmate/ui/view/fragment/HomeFragment.kt
+++ b/app/src/main/java/com/example/cookmate/ui/view/fragment/HomeFragment.kt
@@ -99,12 +99,13 @@ class HomeFragment : Fragment() {
     private fun navigateToRecipeDetails(recipe: Recipe) {
         val intent = Intent(requireContext(), RecipeDetailsActivity::class.java).apply {
             putExtra("recipe_name", recipe.title)
+            putExtra("recipe_description", recipe.recipeDescription)
             putExtra("recipe_image_url", recipe.imageUrl)
             putExtra("recipe_image", recipe.imageRes)
-            putExtra("recipe_difficulty", recipe.difficulty)
-            putExtra("recipe_time", recipe.prepTime)
+            putExtra("recipe_prep_time", recipe.prepTime)
+            putExtra("recipe_time", recipe.cookingTime)
             putExtra("recipe_servings", recipe.servingSize)
-            putExtra("recipe_rating", recipe.rating)
+            putExtra("recipe_preparation_steps", recipe.preparationSteps)
             putExtra("calories", recipe.calories)
             putExtra("fat", recipe.fat)
             putExtra("carbs", recipe.carbs)

--- a/app/src/main/res/layout/activity_recipe_details.xml
+++ b/app/src/main/res/layout/activity_recipe_details.xml
@@ -174,27 +174,27 @@
                 android:layout_marginBottom="8dp"/>
 
             <TextView
+                android:id="@+id/caloriesText"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Calories: (number)"
                 android:layout_marginBottom="4dp"/>
 
             <TextView
+                android:id="@+id/fatText"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Fat: (number)"
                 android:layout_marginBottom="4dp"/>
 
             <TextView
+                android:id="@+id/carbsText"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Carbohydrates: (number)"
                 android:layout_marginBottom="4dp"/>
 
             <TextView
+                android:id="@+id/proteinText"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Protein: (number)"
                 android:layout_marginBottom="8dp"/>
 
             <TextView
@@ -240,7 +240,16 @@
                 android:layout_marginBottom="24dp"
                 app:cardElevation="0dp"
                 app:strokeWidth="1dp"
-                app:strokeColor="@android:color/darker_gray"/>
+                app:strokeColor="@android:color/darker_gray">
+
+                <TextView
+                    android:id="@+id/preparationSteps"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:padding="16dp"
+                    android:scrollbars="vertical"/>
+
+            </com.google.android.material.card.MaterialCardView>
 
             <!-- Action Buttons -->
             <LinearLayout

--- a/app/src/main/res/layout/item_ingredient_detail.xml
+++ b/app/src/main/res/layout/item_ingredient_detail.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Layout for individual ingredient items in recipe details -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:padding="8dp">
+
+    <TextView
+        android:id="@+id/ingredientAmount"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textStyle="bold"
+        android:layout_marginEnd="8dp"/>
+
+    <TextView
+        android:id="@+id/ingredientName"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"/>
+
+</LinearLayout>


### PR DESCRIPTION
- Updated IngredientsAdapter to show substitutes inline with ingredients
- Simplified ingredient item layout for better readability
- Added proper documentation to adapter and layouts
- Changed ingredient format to "5 slices Bread [Toast, Bagel]"
- Removed redundant TextViews and layouts